### PR TITLE
Update UxtGenericManipulatorComponent.cpp

### DIFF
--- a/UXToolsGame/Plugins/UXTools/Source/UXTools/Private/Interactions/UxtGenericManipulatorComponent.cpp
+++ b/UXToolsGame/Plugins/UXTools/Source/UXTools/Private/Interactions/UxtGenericManipulatorComponent.cpp
@@ -48,8 +48,15 @@ void UUxtGenericManipulatorComponent::TickComponent(float DeltaTime, ELevelTick 
 FQuat UUxtGenericManipulatorComponent::GetViewInvariantRotation() const
 {
 	FRotator CameraSpaceYawPitchRotation = UUxtFunctionLibrary::GetHeadPose(GetWorld()).GetRotation().Rotator();
+	
+	// Previously roll was ignored but that meant that the object had it's roll offset everytime the user clicked on it/selected it
+	// when using either MaintainRotationToUser or GravityAlignedMaintainRotationToUser behaviours.
+	// The object rolled in the opposite direction to the roll on the users head.
+	// This did not produce the invariant rotation value we desired, so let's comment out the line below that resets the roll
+	// and instead use the complete world rotation value to calculate the relative orientation value.
+
 	// Ignore roll
-	CameraSpaceYawPitchRotation.Roll = 0.0f;
+	//CameraSpaceYawPitchRotation.Roll = 0.0f;
 
 	return CameraSpaceYawPitchRotation.Quaternion() * InitialCameraSpaceTransform.GetRotation();
 }
@@ -105,7 +112,11 @@ bool UUxtGenericManipulatorComponent::GetOneHandRotation(const FTransform& InSou
 			FQuat OrientationSwing, OrientationTwist;
 			Orientation.ToSwingTwist(FVector::UpVector, OrientationSwing, OrientationTwist);
 
-			OutTargetTransform.SetRotation(Orientation);
+			// Previously the orientation was simply set back to the same value
+			//OutTargetTransform.SetRotation(Orientation);
+
+			//Let's use the Twist component we isolated above to set orientatin such that it always has an upvector matching world.up.
+			OutTargetTransform.SetRotation(OrientationTwist);
 			return true;
 		}
 


### PR DESCRIPTION
Behaviours of grabbed objects was not as expected when using either MaintainRotationToUser or GravityAlignedMaintainRotationToUser options.

I have altered the code to give the behaviours I expected. namely:
MaintainRotationToUser: the object always maintains it's rotation relative to the user's head(camera)
GravityAlignedMaintainRotationToUser: the object maintains it's relative rotation to the user's head around the world up vector only. ie it can only spin around the world up vector

To be fair, the MaintainRotationToUser option in the MRTK Unity 2.3 shows the same pathologies in ManipulationHandler.cs , but the GravityAlignedMaintainRotationToUser in the same file shows what I believe is the correct behaviour...and that is what I have matched in this UXT version.

Hopefully the new behaviour is what others expect also.

This is my first pull request, so I'm not sure what the best practice approach is to document the changes, so I added some comment lines in the file where I made the changes and commented out the relevant previous lines.

Please let me know if that is considered poor form.