### PR TITLE
Fixed typos in the Documentation

### DIFF
--- a/Docs/BoundsControl.md
+++ b/Docs/BoundsControl.md
@@ -12,7 +12,7 @@ keywords: Unreal, Unreal Engine, UE4, HoloLens, HoloLens 2, Mixed Reality, devel
 
 Bounds Control is a component that allows the user to change the position, rotation, and size of an actor, using _affordances_. Affordances are grabbable areas on corners (scale), edges (rotate), and faces (translate) of the actor's bounding box.
 
-To enable bounds control on an actor, add an `UUxtBoundsControlComponent` to it. The component has a default configuration that can be tweaked to change the behavior and appearance as needed.
+To enable bounds control on an actor, add an `UxtBoundsControlComponent` to it. The component has a default configuration that can be tweaked to change the behavior and appearance as needed.
 
 ![BoundsControlComponent](Images/BoundsControl.png)
 
@@ -33,7 +33,7 @@ There are some presets in _BoundsControl/Presets_:
 
 ## Integration with manipulator constraints
 
-The `UUxtBoundsControlComponent` works out of the box with the same constraint components that [Manipulators](./Manipulator.md) use. For example, simply adding and configuring a `UUxtRotationAxisConstraint` component will prevent rotation around the appropriate axes when interacting via affordances.
+The `UxtBoundsControlComponent` works out of the box with the same constraint components that [Manipulators](./Manipulator.md) use. For example, simply adding and configuring a `UxtRotationAxisConstraint` component will prevent rotation around the appropriate axes when interacting via affordances.
 
 ## Affordance meshes
 

--- a/Docs/PressableButton.md
+++ b/Docs/PressableButton.md
@@ -93,7 +93,7 @@ If a blueprint needs to respond to a button event externally, such as a button c
 
 ### Button Actor Variants
 
-A handful of derived `UxtPressableButtonActors` exist to exhibit behavior not found on a typical pressable button. Non-typical behavior includes a binary button state achieved with the `UUxtToggleGroup`. To control groups of mutually exclusive `UxtToggleStates` like [radio buttons](https://en.wikipedia.org/wiki/Radio_button). To make a group of buttons mutually exclusive supply a `UUxtToggleGroup` with a list of `UxtToggleStates`.
+A handful of derived `UxtPressableButtonActors` exist to exhibit behavior not found on a typical pressable button. Non-typical behavior includes a binary button state achieved with the `UxtToggleGroup`. To control groups of mutually exclusive `UxtToggleStates` like [radio buttons](https://en.wikipedia.org/wiki/Radio_button). To make a group of buttons mutually exclusive supply a `UxtToggleGroup` with a list of `UxtToggleStates`.
 
 - `UxtPressableToggleButton`, displays an additional back plate based on the button's `UxtToggleState` checked property.
 
@@ -107,7 +107,7 @@ A handful of derived `UxtPressableButtonActors` exist to exhibit behavior not fo
 
 ![ButtonActorSwitch](Images/PressableButton/ButtonActorSwitch.png)
 
-- `UxtPressableRadioButton`, displays a radio circle icon based on the button's `UxtToggleState` checked property. Radio buttons are intended to be used with the `UUxtToggleGroup` to ensure only one button is checked at a time.
+- `UxtPressableRadioButton`, displays a radio circle icon based on the button's `UxtToggleState` checked property. Radio buttons are intended to be used with the `UxtToggleGroup` to ensure only one button is checked at a time.
 
 ![ButtonActorRadio](Images/PressableButton/ButtonActorRadio.png)
 

--- a/Docs/ReleaseNotes.md
+++ b/Docs/ReleaseNotes.md
@@ -50,7 +50,7 @@ The pinch slider actor has gained a number of quality of life improvements. Thes
 
 #### Constraint support
 
-Manipulation constraints (i.e. derived from `UUxtTransformConstraint`) now also apply to manipulations performed via [bounds control](BoundsControl.md), making it easier to produce a consistent behavior when manipulating transforms.
+Manipulation constraints (i.e. derived from `UxtTransformConstraint`) now also apply to manipulations performed via [bounds control](BoundsControl.md), making it easier to produce a consistent behavior when manipulating transforms.
 
 #### Uniform scaling
 
@@ -96,7 +96,7 @@ Most blueprints will continue to work with no issues but any blueprints that acc
 
 ### UxtHandConstraintComponent
 
-`UUxtHandConstraintComponent::IsHandUsableForConstraint()` is now a non-const member function.
+`UxtHandConstraintComponent::IsHandUsableForConstraint()` is now a non-const member function.
 
 ### UxtPinchSliderActor
 
@@ -115,9 +115,9 @@ Most blueprints will continue to work with no issues but any blueprints that acc
 
 ### UxtBoundsControlComponent
 
-Configuring each affordance's action separately is no longer allowed so, if any feature relied on that, an extension to the `UUxtBoundsControlComponent` should be implemented instead. Besides that, the `EUxtAffordanceAction::Resize` has been removed, so only `EUxtAffordanceAction::Scale` (action of corner affordances) can scale the object in the direction that the grabbed affordance is on, leaving the opposite affordance pinned to its location at the start of the interaction.
+Configuring each affordance's action separately is no longer allowed so, if any feature relied on that, an extension to the `UxtBoundsControlComponent` should be implemented instead. Besides that, the `EUxtAffordanceAction::Resize` has been removed, so only `EUxtAffordanceAction::Scale` (action of corner affordances) can scale the object in the direction that the grabbed affordance is on, leaving the opposite affordance pinned to its location at the start of the interaction.
 
-_Locked Axes_ property in `UUxtBoundsControlConfig` data assets no longer exists. Therefore, if you were using the _Locked Axes_ flags to constrain movement or rotation of an object, you should now add the appropriate `UUxtMoveAxisConstraint` or `UUxtRotationAxisConstraint` (respectively) instead.
+_Locked Axes_ property in `UxtBoundsControlConfig` data assets no longer exists. Therefore, if you were using the _Locked Axes_ flags to constrain movement or rotation of an object, you should now add the appropriate `UxtMoveAxisConstraint` or `UxtRotationAxisConstraint` (respectively) instead.
 
 The _MinimumBoundsScale_ and _MaximumBoundsScale_ properties have been removed in favor of using the `UxtMinMaxScaleConstraint` for controlling this behavior.
 


### PR DESCRIPTION
I saw that inside the scripts like in **U**xtHandConstraintComponent.h we refer to the component as `**UU**xtHandConstraintComponent` but when a user uses Unreal do insert this component, they cannot search for anything that starts with the **UU**x... as for them each component will be find it with their name starting with **Uxt** (e.g. Uxt Hand Constraint).

So I propose this changes removing the double U in this three files in the documentation, I confirm that that is no other citation of a component starting with **UUxt** in the other .md in this Docs folder.